### PR TITLE
dcmrenew returns 'null' response and fails to renew the certificate

### DIFF
--- a/src/main/java/com/github/ibmioss/dcmtools/CertRenewer.java
+++ b/src/main/java/com/github/ibmioss/dcmtools/CertRenewer.java
@@ -38,7 +38,7 @@ public class CertRenewer {
 
         final boolean isYesMode = _opts.isYesMode();
         // Initialize keystore from file of unknown type
-        final KeyStore keyStore = new KeyStoreLoader(null, m_fileNames, null, null, false).getKeyStore();
+        final KeyStore keyStore = new KeyStoreLoader(_logger, m_fileNames, null, null, false).getKeyStore();
 
         for (final String alias : Collections.list(keyStore.aliases())) {
             renewCert(_logger, keyStore.getCertificate(alias),_opts);

--- a/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
+++ b/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
@@ -21,6 +21,7 @@ import com.ibm.as400.access.ObjectDoesNotExistException;
 import com.ibm.as400.access.ProgramCall;
 import com.ibm.as400.access.ProgramParameter;
 import com.ibm.as400.access.ServiceProgramCall;
+import com.ibm.as400.access.Trace;
 
 public class DcmApiCaller implements Closeable {
 
@@ -96,9 +97,9 @@ public class DcmApiCaller implements Closeable {
     }
 
     public void callQycdRenewCertificate_RNWC0300(final AppLogger _logger, final String _file) throws PropertyVetoException, AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException, ObjectDoesNotExistException {
-        final ProgramCall program = new ProgramCall(m_conn);
+        final ProgramCall program = new ServiceProgramCall(m_conn);
         // Initialize the name of the program to run.
-        final String programName = "/QSYS.LIB/QYCDRNWC.PGM";
+        final String programName = "/QSYS.LIB/QICSS.LIB/QYCDRNWC.SRVPGM";
         final String apiFormat = "RNWC0300";
 
         final AS400Structure arg0 = new AS400Structure(new AS400DataType[] {
@@ -110,7 +111,7 @@ public class DcmApiCaller implements Closeable {
                 new AS400Text(_file.length()) }); // TODO
 
         // Set up the parms
-        final ProgramParameter[] parameterList = new ProgramParameter[14];
+        final ProgramParameter[] parameterList = new ProgramParameter[4];
 
         // 1 Certificate request data Input Char(*)
         parameterList[0] = new ProgramParameter(arg0.toBytes(new Object[] { 8, _file.length(), _file }));
@@ -123,6 +124,12 @@ public class DcmApiCaller implements Closeable {
         parameterList[3] = ec;
 
         program.setProgram(programName, parameterList);
+        program.setProcedureName("QycdRenewCertificate");
+
+        // TODO: temp trace data
+        Trace.setTraceOn(true);
+        Trace.setTraceAllOn(true);
+
         // Run the program.
         runProgram(_logger, program, ec);
     }

--- a/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
+++ b/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
@@ -21,7 +21,6 @@ import com.ibm.as400.access.ObjectDoesNotExistException;
 import com.ibm.as400.access.ProgramCall;
 import com.ibm.as400.access.ProgramParameter;
 import com.ibm.as400.access.ServiceProgramCall;
-import com.ibm.as400.access.Trace;
 
 public class DcmApiCaller implements Closeable {
 

--- a/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
+++ b/src/main/java/com/github/ibmioss/dcmtools/utils/DcmApiCaller.java
@@ -97,7 +97,7 @@ public class DcmApiCaller implements Closeable {
     }
 
     public void callQycdRenewCertificate_RNWC0300(final AppLogger _logger, final String _file) throws PropertyVetoException, AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException, ObjectDoesNotExistException {
-        final ProgramCall program = new ServiceProgramCall(m_conn);
+        final ServiceProgramCall program = new ServiceProgramCall(m_conn);
         // Initialize the name of the program to run.
         final String programName = "/QSYS.LIB/QICSS.LIB/QYCDRNWC.SRVPGM";
         final String apiFormat = "RNWC0300";
@@ -125,10 +125,6 @@ public class DcmApiCaller implements Closeable {
 
         program.setProgram(programName, parameterList);
         program.setProcedureName("QycdRenewCertificate");
-
-        // TODO: temp trace data
-        Trace.setTraceOn(true);
-        Trace.setTraceAllOn(true);
 
         // Run the program.
         runProgram(_logger, program, ec);


### PR DESCRIPTION
I've made a couple of fixes to the certificate renewer but this unfortunately isn't the whole story.

Even after these fixes I'm still getting some problems with the dcmrenew command but could do with some help from a Java programmer (I'm not one) who also understands the `com.ibm.as400.access.ServiceProgramCall` class.

When I try running `dcmrenew` using the new code I get the following error.

```
AS400Message (ID: CPF9872 text: Program or service program QYCDRNWC in library QICSS ended. Reason code 2.):com.ibm.as400.access.AS400Message@5e99a5ea
DCM API call failure
```

The CPF9872 message has the following cause text "The specified program or service program was ended due to one of the following: 1 -- A pointer was used that is not available for use while running in the current program state. 2 -- A pointer was used, either directly or as a basing pointer, that has not been set to an address. 3 -- A pointer type was not valid for the requested operation. 4 -- An error was found while checking parameter structure. 5 -- The caller is not allowed to use this interface. Recovery  . . . :   Correct the parameter list passed to the program or service program and try the request again. If the reason code is 5, you will need to use a different interface.".

I've not been able to work out exactly what the problem is here. I did enable `Trace` and it looks to me as though the parameters going in are correct.

Some things about the code that I'm not sure about but on the surface seem wrong.
1. The file passed to the `QycdRenewCertificate` is not the original Base64 encoded certificate given on the command line. It passes a temporary file, generated in the KeyStoreLoader class. The API expects an X509 Base64 encoded file.
2. The `callQycdRenewCertificate_RNWC0300` method executes the `runProgram` method and passes the `ServiceProgramCall` object in as the second parameter. The `runProgram` method expects a `ProgramCall` object as the second parameter. This maybe OK in Java.
